### PR TITLE
Dev

### DIFF
--- a/apps/auth/src/app/app.module.ts
+++ b/apps/auth/src/app/app.module.ts
@@ -38,7 +38,7 @@ import { OAuth2Module } from '@shared/oauth2';
       useFactory: (options: KafkaConfig, config: AuthConfig) => ({
         options,
         mock: config.MOCK_MB,
-        topics: ['user-stream'],
+        topics: ['account-stream'],
       }),
     }),
     OAuth2Module.registerAsync({

--- a/apps/auth/src/auth/auth.controller.ts
+++ b/apps/auth/src/auth/auth.controller.ts
@@ -1,7 +1,46 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query, Res } from '@nestjs/common';
 import { AuthService } from './auth.service';
+import {
+  GetAccessTokenParameters,
+  LoginParameters,
+  VerifyAccessTokenParameters,
+} from '../types';
+import { FastifyReply } from 'fastify';
 
 @Controller()
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  @Get('/oauth/authorize')
+  async authorizeStart(@Res({ passthrough: true }) reply: FastifyReply) {
+    return reply.sendFile('sign-in.html');
+  }
+
+  @Post('/oauth/authorize')
+  async getAuthorizationCode(
+    @Body() { email, password }: LoginParameters,
+    @Query('client_id') client_id: string,
+    @Query('state') state: string,
+    @Res({ passthrough: true }) reply: FastifyReply,
+  ) {
+    const { redirectUrl, code } = await this.authService.getAuthorizationCode({
+      email,
+      password,
+      client_id,
+    });
+
+    return reply
+      .status(302)
+      .redirect(`${redirectUrl}?code=${code}&state=${state}`);
+  }
+
+  @Post('/oauth/token')
+  getAccessToken(@Body() args: GetAccessTokenParameters) {
+    return this.authService.getSignedJwtToken(args);
+  }
+
+  @Post('/oauth/verify')
+  verifyAccessToken(@Body() args: VerifyAccessTokenParameters) {
+    return this.authService.verifyJwtToken(args);
+  }
 }

--- a/apps/auth/src/auth/auth.service.ts
+++ b/apps/auth/src/auth/auth.service.ts
@@ -1,11 +1,148 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
 import { UsersService } from '../users';
+import {
+  GetAuthorizationCodeParameters,
+  GetAuthorizationCodeResponse,
+  GetAccessTokenParameters,
+  LoginParameters,
+  RegisterParameters,
+  RegisterResponse,
+  VerifyAccessTokenParameters,
+  GetAccessTokenResponse,
+  VerifyAccessTokenResponse,
+} from '../types';
 import { ClientAppsService } from '../client-apps';
+import { User } from '../users/users.entity';
+import { ClientApplication } from '../client-apps/client-app.entity';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class AuthService {
+  private authCodeService = new AuthCodeService();
   constructor(
     private readonly usersService: UsersService,
     private readonly appsService: ClientAppsService,
   ) {}
+
+  async register(args: RegisterParameters): Promise<RegisterResponse> {
+    const user = await this.usersService.create(args);
+    return user as any;
+  }
+
+  async getAuthorizationCode(
+    args: GetAuthorizationCodeParameters,
+  ): Promise<GetAuthorizationCodeResponse> {
+    const user = await this.login({
+      email: args.email,
+      password: args.password,
+    });
+    const clientApp = await this.appsService.findOne({
+      clientId: args.client_id,
+    });
+
+    const code = await this.generateAuthorizationCode(user, clientApp);
+
+    return { code, redirectUrl: clientApp.callbackUrl };
+  }
+
+  private async login({ email, password }: LoginParameters) {
+    const user = await this.usersService.findOneByEmail({ email });
+
+    const match = await user.matchPassword(password);
+    if (!match) {
+      throw new ForbiddenException();
+    }
+    return user;
+  }
+
+  async generateAuthorizationCode(user: User, app: ClientApplication) {
+    const code = this.authCodeService.create({
+      userId: user.id,
+      clientId: app.clientId,
+    });
+    return code;
+  }
+
+  async getSignedJwtToken(
+    args: GetAccessTokenParameters,
+  ): Promise<GetAccessTokenResponse> {
+    const app = await this.appsService.findOne({ clientId: args.client_id });
+    if (app.clientSecret !== args.client_secret) {
+      throw new UnauthorizedException();
+    }
+
+    const authCode = this.authCodeService.get(args.code);
+    if (!authCode) {
+      throw new UnauthorizedException();
+    }
+
+    if (authCode.clientId !== args.client_id) {
+      throw new UnauthorizedException();
+    }
+
+    const user = await this.usersService.findOneById(authCode.userId);
+
+    return {
+      access_token: jwt.sign({ id: user.id }, 'JWT_SECRET', {
+        expiresIn: '1d',
+      }),
+    };
+  }
+
+  async verifyJwtToken({
+    access_token,
+  }: VerifyAccessTokenParameters): Promise<VerifyAccessTokenResponse> {
+    const { id } = jwt.verify(access_token, 'JWT_SECRET') as { id: number };
+    const user = await this.usersService.findOneById(id);
+
+    return { access_token, user };
+  }
+}
+
+type AuthCode = {
+  clientId: string;
+  userId: number;
+  scope?: any;
+  expirationDate: Date;
+};
+
+class AuthCodeService {
+  private codes: Record<string, AuthCode> = {};
+  private liveTime = 180000;
+  constructor() {
+    setInterval(() => {
+      for (const [key, code] of Object.entries(this.codes)) {
+        const now = new Date();
+        if (now > code.expirationDate) {
+          delete this.codes[key];
+        }
+      }
+    }, this.liveTime);
+  }
+
+  public create({ clientId, userId }: Omit<AuthCode, 'expirationDate'>) {
+    const expirationDate = new Date(new Date().getTime() + this.liveTime);
+    const key = crypto.randomUUID();
+    this.codes[key] = {
+      clientId,
+      userId,
+      expirationDate,
+    };
+    return key;
+  }
+
+  public get(code: string): AuthCode | null {
+    const authCode = this.codes[code] ?? null;
+    const now = new Date();
+    if (authCode && now > authCode.expirationDate) {
+      delete this.codes[code];
+      return null;
+    }
+    return authCode;
+  }
 }

--- a/apps/auth/src/client-apps/client-app.entity.ts
+++ b/apps/auth/src/client-apps/client-app.entity.ts
@@ -1,7 +1,32 @@
-import { Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, Generated } from 'typeorm';
+import { IClientApplication } from '../types';
 
 @Entity()
-export class ClientApplication {
+export class ClientApplication implements IClientApplication {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @Column()
+  name: string;
+  @Column()
+  baseUrl: string;
+  @Column()
+  callbackUrl: string;
+
+  @Column()
+  @Generated('uuid')
+  clientId: string;
+  @Column()
+  @Generated('uuid')
+  clientSecret: string;
+
+  toJSON(): IClientApplication {
+    return {
+      name: this.name,
+      baseUrl: this.baseUrl,
+      callbackUrl: this.callbackUrl,
+      clientId: this.clientId,
+      clientSecret: this.clientSecret,
+    };
+  }
 }

--- a/apps/auth/src/client-apps/client-apps.controller.ts
+++ b/apps/auth/src/client-apps/client-apps.controller.ts
@@ -1,9 +1,22 @@
-import { Controller } from '@nestjs/common';
-import { Auth } from '@shared/oauth2';
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Auth, Roles } from '@shared/oauth2';
+import { RegisterApplicationParameters } from '../types';
 import { ClientAppsService } from './client-apps.service';
 
 @Controller()
 @Auth()
 export class ClientAppsController {
   constructor(private readonly appsService: ClientAppsService) {}
+
+  @Get('/apps')
+  @Roles('admin')
+  findApps() {
+    return this.appsService.findAll();
+  }
+
+  @Post('/apps')
+  @Roles('admin')
+  registerApp(@Body() args: RegisterApplicationParameters) {
+    return this.appsService.create(args);
+  }
 }

--- a/apps/auth/src/client-apps/client-apps.service.ts
+++ b/apps/auth/src/client-apps/client-apps.service.ts
@@ -1,6 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import {
+  EditApplicationParameters,
+  IClientApplication,
+  RegisterApplicationParameters,
+} from '../types';
 import { ClientApplication } from './client-app.entity';
 
 @Injectable()
@@ -9,4 +14,34 @@ export class ClientAppsService {
     @InjectRepository(ClientApplication)
     private appsRepo: Repository<ClientApplication>,
   ) {}
+
+  async findAll(): Promise<any> {
+    const apps = await this.appsRepo.find();
+    return { results: apps };
+  }
+
+  async create(args: RegisterApplicationParameters) {
+    const created = this.appsRepo.create(args);
+    await this.appsRepo.save(created);
+    return created;
+  }
+
+  async findOne({ clientId }: Pick<IClientApplication, 'clientId'>) {
+    const user = await this.appsRepo.findOneBy({ clientId });
+    if (!user) {
+      throw new NotFoundException(`App ${clientId} doesn't exist`);
+    }
+    return user;
+  }
+
+  async update({ clientId, ...args }: EditApplicationParameters) {
+    const updated = await this.findOne({ clientId });
+    await this.appsRepo.save(Object.assign(updated, args));
+    return updated;
+  }
+
+  async delete({ clientId }: Pick<IClientApplication, 'clientId'>) {
+    const deleted = await this.findOne({ clientId });
+    return this.appsRepo.remove(deleted);
+  }
 }

--- a/apps/auth/src/types.ts
+++ b/apps/auth/src/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Users
+ */
+
+export const userRoles = ['admin', 'manager', 'accountant', 'user'] as const;
+export type UserRoleType = typeof userRoles[number];
+
+export interface IUser {
+  publicId: string;
+  email: string;
+  name: string;
+  role?: UserRoleType;
+}
+
+export type FindUsersResponse = {
+  results: IUser[];
+};
+
+export type RegisterParameters = {
+  name: string;
+  email: string;
+  password: string;
+  role?: UserRoleType;
+};
+export type RegisterResponse = IUser;
+
+/**
+ * Applications
+ */
+export interface IClientApplication {
+  name: string;
+  baseUrl: string;
+  callbackUrl: string;
+
+  clientId: string;
+  clientSecret: string;
+}
+
+export type RegisterApplicationParameters = {
+  name: string;
+  baseUrl: string;
+  callbackUrl: string;
+};
+
+export type EditApplicationParameters = {
+  clientId: string;
+  name?: string;
+  baseUrl?: string;
+  callbackUrl?: string;
+};
+
+/**
+ * OAuth
+ */
+
+// Authorization Code
+export type LoginParameters = {
+  email: string;
+  password: string;
+};
+export type GetAuthorizationCodeParameters = LoginParameters & {
+  client_id: string;
+};
+export type GetAuthorizationCodeResponse = {
+  code: string;
+  redirectUrl: string;
+};
+
+// Access Token
+export type GetAccessTokenParameters = {
+  code: string;
+  client_id: string;
+  client_secret: string;
+};
+export type GetAccessTokenResponse = {
+  access_token: string;
+};
+
+export type VerifyAccessTokenParameters = {
+  access_token: string;
+};
+
+export type VerifyAccessTokenResponse = {
+  access_token: string;
+  user: IUser;
+};

--- a/apps/auth/src/users/users.controller.ts
+++ b/apps/auth/src/users/users.controller.ts
@@ -1,9 +1,42 @@
-import { Controller } from '@nestjs/common';
-import { Auth } from '@shared/oauth2';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { Auth, Roles } from '@shared/oauth2';
+import { RegisterParameters } from '../types';
 import { UsersService } from './users.service';
 
 @Controller()
 @Auth()
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  @Get('/accounts')
+  @Roles('admin', 'manager')
+  findAccounts() {
+    return this.usersService.findAll();
+  }
+
+  @Post('/accounts')
+  @Roles('admin')
+  createAccount(@Body() args: RegisterParameters) {
+    return this.usersService.create(args);
+  }
+
+  @Patch('/accounts/:id')
+  @Roles('admin')
+  editAccount(@Param('id') id: string, @Body() args: any) {
+    return this.usersService.update({ publicId: id, ...args });
+  }
+
+  @Delete('/accounts/:id')
+  @Roles('admin')
+  deleteAccount(@Param('id') id: string) {
+    return this.usersService.delete({ publicId: id });
+  }
 }

--- a/apps/auth/src/users/users.entity.ts
+++ b/apps/auth/src/users/users.entity.ts
@@ -1,7 +1,56 @@
-import { Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  Generated,
+  BaseEntity,
+  BeforeInsert,
+} from 'typeorm';
+import * as bcrypt from 'bcryptjs';
+import { IUser, userRoles, UserRoleType } from '../types';
 
 @Entity()
-export class User {
+export class User extends BaseEntity implements IUser {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @Column()
+  @Generated('uuid')
+  publicId: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  email: string;
+
+  @Column()
+  password: string;
+
+  @Column({
+    type: 'enum',
+    enum: userRoles,
+    default: 'user',
+  })
+  role: UserRoleType;
+
+  toJSON(): IUser {
+    return {
+      publicId: this.publicId,
+      name: this.name,
+      email: this.email,
+      role: this.role,
+    };
+  }
+
+  @BeforeInsert()
+  async beforeInsert() {
+    const salt = await bcrypt.genSalt(10);
+    const passwordHash = await bcrypt.hash(this.password, salt);
+    this.password = passwordHash;
+  }
+
+  async matchPassword(enteredPassword: string) {
+    return bcrypt.compare(enteredPassword, this.password);
+  }
 }

--- a/apps/auth/src/users/users.service.ts
+++ b/apps/auth/src/users/users.service.ts
@@ -1,8 +1,9 @@
-import { Logger } from '@nestjs/common';
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ClientKafkaService } from '@shared/kafka';
 import { Repository } from 'typeorm';
+import { FindUsersResponse, IUser } from '../types';
 import { User } from './users.entity';
 
 @Injectable()
@@ -12,4 +13,75 @@ export class UsersService {
     @InjectRepository(User) private userRepo: Repository<User>,
     private client: ClientKafkaService,
   ) {}
+
+  async findAll(findParams?: Pick<IUser, 'name'>): Promise<FindUsersResponse> {
+    let users: IUser[];
+    if (!findParams) {
+      users = await this.userRepo.find();
+    } else {
+      users = await this.userRepo.findBy(findParams);
+    }
+    return { results: users };
+  }
+
+  async create(args: Omit<IUser, 'publicId'>) {
+    const user = await this.userRepo.findOneBy({ email: args.email });
+    if (user) {
+      throw new ForbiddenException(`Email ${args.email} already exists`);
+    }
+    const created = this.userRepo.create(args);
+    await this.userRepo.save(created);
+    await this.client.emit('account-stream', {
+      name: 'AccountCreated',
+      data: created,
+    });
+    this.logger.debug(`User ${created.email} created`);
+    return created;
+  }
+
+  async findOne({ publicId }: Pick<IUser, 'publicId'>) {
+    const user = await this.userRepo.findOneBy({ publicId });
+    if (!user) {
+      throw new NotFoundException(`User ${publicId} doesn't exist`);
+    }
+    return user;
+  }
+
+  async findOneById(id: number) {
+    const user = await this.userRepo.findOneBy({ id });
+    if (!user) {
+      throw new NotFoundException(`User doesn't exist`);
+    }
+    return user;
+  }
+
+  async findOneByEmail({ email }: Pick<IUser, 'email'>) {
+    const user = await this.userRepo.findOneBy({ email });
+    if (!user) {
+      throw new NotFoundException(`User ${email} doesn't exist`);
+    }
+    return user;
+  }
+
+  async update({ publicId, ...args }: Partial<IUser> & Pick<User, 'publicId'>) {
+    const updated = await this.findOne({ publicId });
+    await this.userRepo.save(Object.assign(updated, args));
+    await this.client.emit('account-stream', {
+      name: 'AccountUpdated',
+      data: updated,
+    });
+    this.logger.debug(`User ${updated.email} updated`);
+    return updated;
+  }
+
+  async delete({ publicId }: Pick<IUser, 'publicId'>) {
+    const deleted = await this.findOne({ publicId });
+    await this.userRepo.remove(deleted);
+    await this.client.emit('account-stream', {
+      name: 'AccountDeleted',
+      data: deleted,
+    });
+    this.logger.debug(`User ${deleted.email} deleted`);
+    return deleted;
+  }
 }

--- a/apps/tasks/src/kafka-app/kafka-app.controller.ts
+++ b/apps/tasks/src/kafka-app/kafka-app.controller.ts
@@ -1,7 +1,13 @@
 import { Controller } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import { UserCreatedEvent } from '../types';
 import { UsersConsumerService } from './user-consumer.service';
 
 @Controller()
 export class KafkaAppController {
   constructor(private userConsumer: UsersConsumerService) {}
+  @MessagePattern('account-stream')
+  async getUserMessage(@Payload() payload: UserCreatedEvent) {
+    this.userConsumer.consume(payload);
+  }
 }

--- a/apps/tasks/src/kafka-app/user-consumer.service.ts
+++ b/apps/tasks/src/kafka-app/user-consumer.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Task } from '../tasks';
+import { UserCreatedEvent } from '../types';
 import { User } from '../users';
 
 @Injectable()
@@ -12,4 +13,44 @@ export class UsersConsumerService {
     @InjectRepository(User) private userRepo: Repository<User>,
     @InjectRepository(Task) private taskRepo: Repository<Task>,
   ) {}
+  async consume(event: UserCreatedEvent) {
+    switch (event.name) {
+      case 'AccountCreated':
+        const created = this.userRepo.create(event.data);
+        await this.userRepo.save(created);
+        this.logger.debug(`User ${created.email} created`);
+        break;
+      case 'AccountUpdated':
+        let user = await this.userRepo.findOneBy({
+          publicId: event.data.publicId,
+        });
+        if (!user) {
+          user = this.userRepo.create(event.data);
+          await this.userRepo.save(user);
+          this.logger.debug(`User ${user.email} created`);
+        } else {
+          await this.userRepo.save(Object.assign(user, event.data));
+          this.logger.debug(`User ${user.email} updated`);
+        }
+        break;
+      case 'AccountDeleted':
+        const deleted = await this.userRepo.findOne({
+          where: {
+            publicId: event.data.publicId,
+          },
+          relations: ['tasks'],
+        });
+        if (deleted) {
+          for (const task of deleted.tasks) {
+            task.assignee = null;
+            this.taskRepo.save(task);
+          }
+          await this.userRepo.remove(deleted);
+          this.logger.debug(`User ${deleted.email} deleted`);
+        }
+        break;
+      default:
+        break;
+    }
+  }
 }

--- a/apps/tasks/src/tasks/commands/assign-tasks.handler.ts
+++ b/apps/tasks/src/tasks/commands/assign-tasks.handler.ts
@@ -1,0 +1,76 @@
+import { Logger } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Not, Repository } from 'typeorm';
+import { User } from '../../users';
+import { AssignTasksCommand } from './tasks.commands';
+import { Task } from '../task.entity';
+import { ClientKafkaService } from '@shared/kafka';
+
+@CommandHandler(AssignTasksCommand)
+export class AssignTasksHandler implements ICommandHandler<AssignTasksCommand> {
+  private readonly logger = new Logger(AssignTasksHandler.name);
+  constructor(
+    @InjectRepository(Task) private taskRepo: Repository<Task>,
+
+    @InjectRepository(User) private userRepo: Repository<User>,
+    private dataSource: DataSource,
+    private client: ClientKafkaService,
+  ) {}
+
+  async execute(args: AssignTasksCommand): Promise<any> {
+    const users = await this.userRepo
+      .createQueryBuilder('user')
+      .select()
+      .orderBy('random()')
+      .getMany();
+
+    const notCompletedTasks = await this.taskRepo
+      .createQueryBuilder('task')
+      .where('task.status <> :status', { status: 'done' })
+      .leftJoinAndSelect('task.assignee', 'assignee')
+      .orderBy('random()')
+      .getMany();
+
+    const tasksDict = {};
+    const messages: any[] = [];
+
+    await this.dataSource.transaction(async (manager) => {
+      while (notCompletedTasks.length) {
+        const randomTaskIdx = Math.floor(
+          Math.random() * notCompletedTasks.length,
+        );
+        const randomUserIdx = Math.floor(Math.random() * users.length);
+
+        const task = notCompletedTasks[randomTaskIdx];
+        notCompletedTasks.splice(randomTaskIdx, 1);
+        const user = users[randomUserIdx];
+
+        Object.assign(task, { assignee: user });
+
+        await manager.save(task);
+        await manager.save(user);
+
+        messages.push({
+          name: 'TaskAssigned',
+          data: {
+            description: task.description,
+            assigneeId: user.publicId,
+          },
+        });
+
+        if (tasksDict[user.publicId]) {
+          tasksDict[user.publicId].push(task.publicId);
+        } else {
+          tasksDict[user.publicId] = [task.publicId];
+        }
+      }
+    });
+
+    await this.client.emitMutliple('task', messages);
+
+    this.logger.debug('Assign free tasks');
+
+    return tasksDict;
+  }
+}

--- a/apps/tasks/src/tasks/commands/create-task.handler.ts
+++ b/apps/tasks/src/tasks/commands/create-task.handler.ts
@@ -1,0 +1,60 @@
+import { Logger, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../../users';
+import { CreateTaskCommand } from './tasks.commands';
+import { Task } from '../task.entity';
+import { ClientKafkaService } from '@shared/kafka';
+
+@CommandHandler(CreateTaskCommand)
+export class CreateTaskHandler implements ICommandHandler<CreateTaskCommand> {
+  private readonly logger = new Logger(CreateTaskHandler.name);
+  constructor(
+    @InjectRepository(Task) private taskRepo: Repository<Task>,
+
+    @InjectRepository(User) private userRepo: Repository<User>,
+    private client: ClientKafkaService,
+  ) {}
+
+  async execute({
+    payload: { assigneeId, ...args },
+  }: CreateTaskCommand): Promise<any> {
+    let user: User | null = null;
+    if (assigneeId) {
+      user = await this.userRepo.findOneBy({ publicId: assigneeId });
+    }
+
+    if (!user) {
+      user = await this.userRepo
+        .createQueryBuilder('user')
+        .select()
+        .orderBy('random()')
+        .getOne();
+    }
+
+    if (!user) {
+      throw new NotFoundException('There is no users!');
+    }
+
+    const task = this.taskRepo.create({ ...args });
+    task.assignee = user;
+    await this.taskRepo.save(task);
+    await this.userRepo.save(user);
+
+    await this.client.emit('task', {
+      name: 'TaskAssigned',
+      data: {
+        description: task.description,
+        assigneeId: user.publicId,
+      },
+    });
+    await this.client.emit('task-stream', {
+      name: 'TaskCreated',
+      data: task,
+    });
+    this.logger.debug(`Task ${task.description} created`);
+
+    return task;
+  }
+}

--- a/apps/tasks/src/tasks/commands/delete-task.handler.ts
+++ b/apps/tasks/src/tasks/commands/delete-task.handler.ts
@@ -1,0 +1,33 @@
+import { Logger, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../../users';
+import { DeleteTaskCommand } from './tasks.commands';
+import { Task } from '../task.entity';
+import { ClientKafkaService } from '@shared/kafka';
+
+@CommandHandler(DeleteTaskCommand)
+export class DeleteTaskHandler implements ICommandHandler<DeleteTaskCommand> {
+  private readonly logger = new Logger(DeleteTaskHandler.name);
+  constructor(
+    @InjectRepository(Task) private taskRepo: Repository<Task>,
+
+    @InjectRepository(User) private userRepo: Repository<User>,
+    private client: ClientKafkaService,
+  ) {}
+
+  async execute({ payload: { taskId } }: DeleteTaskCommand): Promise<any> {
+    const deleted = await this.taskRepo.findOneBy({ publicId: taskId });
+    if (!deleted) {
+      throw new NotFoundException(`Task ${taskId} doesn't exist`);
+    }
+    await this.taskRepo.remove(deleted);
+    await this.client.emit('task-stream', {
+      name: 'TaskDeleted',
+      data: deleted,
+    });
+    this.logger.debug(`Task ${deleted.description} deleted`);
+    return deleted;
+  }
+}

--- a/apps/tasks/src/tasks/commands/index.ts
+++ b/apps/tasks/src/tasks/commands/index.ts
@@ -1,0 +1,5 @@
+export * from './tasks.commands';
+export * from './create-task.handler';
+export * from './update-task.handler';
+export * from './delete-task.handler';
+export * from './assign-tasks.handler';

--- a/apps/tasks/src/tasks/commands/tasks.commands.ts
+++ b/apps/tasks/src/tasks/commands/tasks.commands.ts
@@ -1,0 +1,23 @@
+import { ICommand } from '@shared/cqrs';
+import {
+  AssignTasksParameters,
+  CreateTaskParameters,
+  DeleteTaskParameters,
+  UpdateTaskParameters,
+} from '../../types';
+
+export class CreateTaskCommand implements ICommand<CreateTaskParameters> {
+  constructor(public payload: CreateTaskParameters) {}
+}
+
+export class UpdateTaskCommand implements ICommand<UpdateTaskParameters> {
+  constructor(public payload: UpdateTaskParameters) {}
+}
+
+export class DeleteTaskCommand implements ICommand<UpdateTaskParameters> {
+  constructor(public payload: DeleteTaskParameters) {}
+}
+
+export class AssignTasksCommand implements ICommand<AssignTasksParameters> {
+  constructor(public payload: AssignTasksParameters) {}
+}

--- a/apps/tasks/src/tasks/commands/update-task.handler.ts
+++ b/apps/tasks/src/tasks/commands/update-task.handler.ts
@@ -1,0 +1,72 @@
+import { Logger, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../../users';
+import { UpdateTaskCommand } from './tasks.commands';
+import { Task } from '../task.entity';
+import { ClientKafkaService } from '@shared/kafka';
+
+@CommandHandler(UpdateTaskCommand)
+export class UpdateTaskHandler implements ICommandHandler<UpdateTaskCommand> {
+  private readonly logger = new Logger(UpdateTaskHandler.name);
+  constructor(
+    @InjectRepository(Task) private taskRepo: Repository<Task>,
+
+    @InjectRepository(User) private userRepo: Repository<User>,
+    private client: ClientKafkaService,
+  ) {}
+
+  async execute({
+    payload: { taskId, assigneeId, ...args },
+  }: UpdateTaskCommand): Promise<any> {
+    const task = await this.taskRepo.findOne({
+      where: { publicId: taskId },
+      relations: ['assignee'],
+    });
+    if (!task) {
+      throw new NotFoundException(`Task ${taskId} doesn't exist`);
+    }
+
+    let newAssignee: User | null = null;
+    if (assigneeId && assigneeId !== task.assignee?.publicId) {
+      newAssignee = await this.userRepo.findOneBy({ publicId: assigneeId });
+      if (!newAssignee) {
+        throw new NotFoundException(`User ${newAssignee} doesn't exist`);
+      }
+    }
+
+    const isDone = args.status === 'done' && args.status !== task.status;
+
+    await this.taskRepo.save(Object.assign(task, args));
+
+    if (isDone) {
+      await this.client.emit('task', {
+        name: 'TaskCompleted',
+        data: {
+          description: task.description,
+          assigneeId: task.assignee?.publicId,
+        },
+      });
+      this.logger.debug(`Task ${task.description} completed`);
+    } else if (newAssignee) {
+      await this.client.emit('task', {
+        name: 'TaskAssigned',
+        data: {
+          description: task.description,
+          assigneeId: newAssignee.publicId,
+        },
+      });
+      this.logger.debug(`Task ${task.description} assigned`);
+    }
+
+    await this.client.emit('task-stream', {
+      name: 'TaskUpdated',
+      data: task,
+    });
+
+    this.logger.debug(`Task ${task.description} updated`);
+
+    return task;
+  }
+}

--- a/apps/tasks/src/tasks/queries/find-task.handler.ts
+++ b/apps/tasks/src/tasks/queries/find-task.handler.ts
@@ -1,0 +1,19 @@
+import { NotFoundException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Task } from '../task.entity';
+import { FindTaskQuery } from './quieries';
+
+@QueryHandler(FindTaskQuery)
+export class FindTaskHandler implements IQueryHandler<FindTaskQuery> {
+  constructor(@InjectRepository(Task) private taskRepo: Repository<Task>) {}
+
+  async execute({ payload: { taskId } }: FindTaskQuery): Promise<any> {
+    const task = await this.taskRepo.findOneBy({ publicId: taskId });
+    if (!task) {
+      throw new NotFoundException(`Task ${taskId} doesn't exist`);
+    }
+    return task;
+  }
+}

--- a/apps/tasks/src/tasks/queries/find-tasks.handler.ts
+++ b/apps/tasks/src/tasks/queries/find-tasks.handler.ts
@@ -1,0 +1,18 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Task } from '../task.entity';
+import { FindTasksQuery } from './quieries';
+
+@QueryHandler(FindTasksQuery)
+export class FindTasksHandler implements IQueryHandler<FindTasksQuery> {
+  constructor(@InjectRepository(Task) private taskRepo: Repository<Task>) {}
+
+  async execute({ payload }: FindTasksQuery): Promise<any> {
+    const tasks = await this.taskRepo.find({
+      where: payload,
+      relations: ['assignee'],
+    });
+    return { results: tasks };
+  }
+}

--- a/apps/tasks/src/tasks/queries/index.ts
+++ b/apps/tasks/src/tasks/queries/index.ts
@@ -1,0 +1,3 @@
+export * from './quieries';
+export * from './find-task.handler';
+export * from './find-tasks.handler';

--- a/apps/tasks/src/tasks/queries/quieries.ts
+++ b/apps/tasks/src/tasks/queries/quieries.ts
@@ -1,0 +1,10 @@
+import { IQuery } from '@shared/cqrs';
+import { FindTasksParameters, GetTaskParameters } from '../../types';
+
+export class FindTasksQuery implements IQuery<FindTasksParameters> {
+  constructor(public payload: FindTasksParameters) {}
+}
+
+export class FindTaskQuery implements IQuery<GetTaskParameters> {
+  constructor(public payload: GetTaskParameters) {}
+}

--- a/apps/tasks/src/tasks/task.controller.ts
+++ b/apps/tasks/src/tasks/task.controller.ts
@@ -1,9 +1,55 @@
-import { Controller } from '@nestjs/common';
-import { Auth } from '@shared/oauth2';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { Auth, Roles } from '@shared/oauth2';
+import {
+  AssignTasksParameters,
+  CreateTaskParameters,
+  FindTasksParameters,
+  UpdateTaskParameters,
+} from '../types';
 import { TaskService } from './task.service';
 
 @Controller()
 @Auth()
 export class TaskController {
   constructor(private readonly taskService: TaskService) {}
+
+  @Get('tasks')
+  findAll(@Query() args: FindTasksParameters) {
+    return this.taskService.findAll(args);
+  }
+
+  @Post('tasks')
+  create(@Body() args: CreateTaskParameters) {
+    return this.taskService.create(args);
+  }
+
+  @Get('tasks/:taskId')
+  findOne(@Param('taskId') taskId: string) {
+    return this.taskService.findOne({ taskId });
+  }
+
+  @Patch('tasks/:taskId')
+  update(@Param('taskId') taskId: string, @Body() args: UpdateTaskParameters) {
+    return this.taskService.update({ ...args, taskId });
+  }
+
+  @Delete('tasks/:taskId')
+  delete(@Param('taskId') taskId: string) {
+    return this.taskService.delete({ taskId });
+  }
+
+  @Post('tasks/assign')
+  @Roles('admin', 'manager')
+  assign(@Body() args: AssignTasksParameters) {
+    return this.taskService.assign(args);
+  }
 }

--- a/apps/tasks/src/tasks/task.entity.ts
+++ b/apps/tasks/src/tasks/task.entity.ts
@@ -1,7 +1,41 @@
-import { Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  Generated,
+  ManyToOne,
+} from 'typeorm';
+import { ITask, TaskStatus, taskStatuses } from '../types';
+import { User } from '../users';
 
 @Entity()
 export class Task {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @Column()
+  @Generated('uuid')
+  publicId: string;
+
+  @Column()
+  description: string;
+
+  @Column({
+    type: 'enum',
+    enum: taskStatuses,
+    default: 'todo',
+  })
+  status: TaskStatus;
+
+  @ManyToOne(() => User, (user) => user.tasks, { nullable: true })
+  assignee: User | null;
+
+  toJSON(): ITask {
+    return {
+      publicId: this.publicId,
+      description: this.description,
+      status: this.status,
+      assignee: this.assignee,
+    };
+  }
 }

--- a/apps/tasks/src/tasks/task.module.ts
+++ b/apps/tasks/src/tasks/task.module.ts
@@ -2,6 +2,13 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from '../users';
+import {
+  CreateTaskHandler,
+  UpdateTaskHandler,
+  DeleteTaskHandler,
+  AssignTasksHandler,
+} from './commands';
+import { FindTaskHandler, FindTasksHandler } from './queries';
 import { TaskController } from './task.controller';
 import { Task } from './task.entity';
 import { TaskService } from './task.service';
@@ -9,7 +16,15 @@ import { TaskService } from './task.service';
 @Module({
   imports: [CqrsModule, TypeOrmModule.forFeature([Task]), UsersModule],
   controllers: [TaskController],
-  providers: [TaskService],
+  providers: [
+    CreateTaskHandler,
+    UpdateTaskHandler,
+    DeleteTaskHandler,
+    AssignTasksHandler,
+    FindTaskHandler,
+    FindTasksHandler,
+    TaskService,
+  ],
   exports: [TypeOrmModule],
 })
 export class TasksModule {}

--- a/apps/tasks/src/tasks/task.service.ts
+++ b/apps/tasks/src/tasks/task.service.ts
@@ -1,7 +1,46 @@
 import { Injectable } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import {
+  AssignTasksParameters,
+  CreateTaskParameters,
+  DeleteTaskParameters,
+  FindTasksParameters,
+  GetTaskParameters,
+  UpdateTaskParameters,
+} from '../types';
+import {
+  AssignTasksCommand,
+  CreateTaskCommand,
+  DeleteTaskCommand,
+  UpdateTaskCommand,
+} from './commands';
+import { FindTaskQuery, FindTasksQuery } from './queries';
 
 @Injectable()
 export class TaskService {
   constructor(private commandBus: CommandBus, private queryBus: QueryBus) {}
+
+  async findAll(args?: FindTasksParameters) {
+    return this.queryBus.execute(new FindTasksQuery(args ?? {}));
+  }
+
+  async create(args: CreateTaskParameters) {
+    return this.commandBus.execute(new CreateTaskCommand(args));
+  }
+
+  async findOne(args: GetTaskParameters) {
+    return this.queryBus.execute(new FindTaskQuery(args ?? {}));
+  }
+
+  async update(args: UpdateTaskParameters) {
+    return this.commandBus.execute(new UpdateTaskCommand(args));
+  }
+
+  async delete(args: DeleteTaskParameters) {
+    return this.commandBus.execute(new DeleteTaskCommand(args));
+  }
+
+  async assign(args: AssignTasksParameters) {
+    return this.commandBus.execute(new AssignTasksCommand(args));
+  }
 }

--- a/apps/tasks/src/types.ts
+++ b/apps/tasks/src/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Users
+ */
+
+export const userRoles = ['admin', 'manager', 'accountant', 'user'] as const;
+export type UserRoleType = typeof userRoles[number];
+
+export type UserId = string;
+
+export interface IUser {
+  publicId: UserId;
+  email: string;
+  name: string;
+  role?: UserRoleType;
+}
+
+export type UserCreatedEvent = {
+  name: 'AccountCreated' | 'AccountUpdated' | 'AccountDeleted';
+  data: IUser;
+};
+
+/**
+ * Tasks
+ */
+
+export type TaskId = string;
+
+export const taskStatuses = ['todo', 'in-progess', 'done'] as const;
+export type TaskStatus = typeof taskStatuses[number];
+
+export interface ITask {
+  publicId: TaskId;
+  assignee: IUser | null;
+  description: string;
+  status: TaskStatus;
+}
+
+export type FindTasksParameters = {
+  status?: TaskStatus;
+};
+export type FindTasksResponse = {
+  results: ITask;
+};
+
+export interface CreateTaskParameters {
+  assigneeId?: UserId;
+  description: string;
+  status?: TaskStatus;
+}
+export type CreateTaskResponse = ITask;
+
+export type GetTaskParameters = {
+  taskId: TaskId;
+};
+export type GetTaskResponse = ITask;
+
+export type UpdateTaskParameters = {
+  taskId: TaskId;
+  assigneeId?: UserId;
+  description?: string;
+  status?: TaskStatus;
+};
+export type UpdateTaskResponse = ITask;
+
+export type DeleteTaskParameters = { taskId: TaskId };
+export type DeleteTaskResponse = ITask;
+
+export type AssignTasksParameters = any;
+export type AssignTasksResponse = any;

--- a/apps/tasks/src/users/users.entity.ts
+++ b/apps/tasks/src/users/users.entity.ts
@@ -1,7 +1,37 @@
-import { Entity, PrimaryGeneratedColumn, BaseEntity } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+import { Task } from '../tasks';
+import { IUser, userRoles, UserRoleType } from '../types';
 
 @Entity()
-export class User extends BaseEntity {
+export class User {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @Column('uuid')
+  publicId: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  email: string;
+
+  @Column({
+    type: 'enum',
+    enum: userRoles,
+    default: 'user',
+  })
+  role: UserRoleType;
+
+  @OneToMany(() => Task, (task) => task.assignee, { cascade: ['remove'] })
+  tasks: Task[];
+
+  toJSON(): IUser {
+    return {
+      publicId: this.publicId,
+      name: this.name,
+      email: this.email,
+      role: this.role,
+    };
+  }
 }

--- a/docs/api/auth.http
+++ b/docs/api/auth.http
@@ -6,6 +6,8 @@
 # get token
 GET {{baseUrl}}/login
 
+### 
+
 # create user
 # pupa@mail.com qwerty
 # igor@mail.com boss

--- a/docs/api/auth.http
+++ b/docs/api/auth.http
@@ -1,17 +1,23 @@
 @baseUrl = http://localhost:3000
-@token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjIsImlhdCI6MTY2NTkyNjAzOCwiZXhwIjoxNjY2MDEyNDM4fQ.ra5J9VjrB34yPRwHP6ydUZmsG3bW6rf_DJg474NCVWg
+@token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY1OTg1NjE5LCJleHAiOjE2NjYwNzIwMTl9.IUU-xMABSig3ETuQHAHeOGLojcpfgRIVNzzAk51aj8c
+
+###
+
+# get token
+GET {{baseUrl}}/login
 
 # create user
 # pupa@mail.com qwerty
 # igor@mail.com boss
 POST {{baseUrl}}/accounts
-Content-Type: application/json 
+Content-Type: application/json
+Authorization: Bearer {{token}}
 
 {
   "name": "igor",
   "email": "igor@mail.com",
   "password": "boss",
-  "role": "manager"
+  "role": "admin"
 }
 
 ###

--- a/docs/api/tasks.http
+++ b/docs/api/tasks.http
@@ -2,7 +2,7 @@
 @baseUrl = http://localhost:4000
 
 # get token using http://localhost:4000/login
-@token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjIsImlhdCI6MTY2NTkyNjAzOCwiZXhwIjoxNjY2MDEyNDM4fQ.ra5J9VjrB34yPRwHP6ydUZmsG3bW6rf_DJg474NCVWg
+@token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY1OTg1NjE5LCJleHAiOjE2NjYwNzIwMTl9.IUU-xMABSig3ETuQHAHeOGLojcpfgRIVNzzAk51aj8c
 
 ###
 
@@ -11,7 +11,7 @@ GET {{baseUrl}}/login
 
 ###
 
-GET {{baseUrl}}/tasks?status=done
+GET {{baseUrl}}/tasks
 Content-Type: application/json
 Authorization: Bearer {{token}} 
 


### PR DESCRIPTION
Это второе ДЗ.

Все написано на фреймворке [nest.js](https://nestjs.com).

Для коммуникации с Кафкой используется модуль фреймворка [@nestjs/microservices](https://docs.nestjs.com/microservices/basics), использующий под капотом kafkajs.  
В нем не реализован батчинг, поэтому пришлось залезть в его кишочки https://github.com/borolgs/aTES/blob/dev/libs/shared/src/kafka/server-kafka.ts.
Пока сделан только батчинг на отправку сообщений.

Для аутентификации на стороне клиентских приложений используется [готовое решение для OAuth2.0](https://github.com/fastify/fastify-oauth2).  
И сделана [минимальная обертка](https://github.com/borolgs/aTES/blob/dev/libs/shared/src/oauth2/oauth2.service.ts) для интеграции в nestjs, чтобы делать такие штуки:  
```ts
@Get('/apps')
@Auth()
@Roles('admin')
findApps() {
  return this.appsService.findAll();
}
```
На стороне сервиса аутентификации сделана достаточно грубая имитация, но с поддержкой authorization code flow.

По основной логике:
auth приложение отправляет CUD События которые обрабатываются в [консьюмере таск-треккера](https://github.com/borolgs/aTES/blob/dev/apps/tasks/src/kafka-app/user-consumer.service.ts).
Таск-трекер отправляет бизнес события при назначении и завершении задач.  
При ассайне события назначения отправляются [всей пачкой](https://github.com/borolgs/aTES/blob/dev/apps/tasks/src/tasks/commands/assign-tasks.handler.ts#L21).

В приложении tasks CQRS реализован с помощью коробочного модуля [@nestjs/cqrs](https://docs.nestjs.com/recipes/cqrs#cqrs).  
Пока просто разделены command и query. 


